### PR TITLE
Improved, conditional JPEG and Subtitle track creation

### DIFF
--- a/Chapter.m
+++ b/Chapter.m
@@ -13,7 +13,7 @@
 -(NSString *) stringForXPath:(NSString*)xpath error:(NSError**)error
 {
     NSArray *nodes = [self nodesForXPath:xpath error:error];
-
+    
     if ([nodes count])
         return [[nodes objectAtIndex:0] stringValue];
     else
@@ -28,7 +28,7 @@ static NSInteger timeToMilliseconds(NSString* timeString)
     NSInteger timeValue = 0;
     if ([chunks count] == 0)
         return 0;
-
+    
     int idx = 0;
     if ([chunks count] == 3) {
         timeValue += [[chunks objectAtIndex:idx] intValue] * 3600 * 1000;
@@ -72,20 +72,21 @@ static NSInteger timeToMilliseconds(NSString* timeString)
     self.title = [node stringForXPath:@"./title[1]" error:&xmlError];
     self.link = [node stringForXPath:@"./link[1]/@href" error:&xmlError];
     self.linkText = [node stringForXPath:@"./link[1]" error:&xmlError];
-    if (_xmlPath == nil)
+    
+    // do not set artPath if <picture> element is missing
+    NSString *path = [node stringForXPath:@"./picture[1]" error:&xmlError];
+    if (_xmlPath == nil || path == nil)
         self.artPath = [node stringForXPath:@"./picture[1]" error:&xmlError];
     else
     {
         NSString *path = [node stringForXPath:@"./picture[1]" error:&xmlError];
         self.artPath = [_xmlPath stringByAppendingPathComponent:path];
-        //  NSLog(@"Test: %@ -> %@", path, self.artPath);
     }
     return self;
 }
 
 - (id) initWithXMLNode: (NSXMLNode*)node path:(NSString*)path
 {
-    NSError *xmlError;
     self = [self init];
     _xmlPath = [path copy];
     self = [self initWithXMLNode:node];

--- a/ChaptersEditor.mm
+++ b/ChaptersEditor.mm
@@ -20,23 +20,24 @@ extern "C" {
 using namespace std;
 
 #define ITUNES_COVER_SIZE 300
-#define HAVE_SUBTITLES 1
+bool CREATE_SUBTITLES = false;
+bool CREATE_JPEG_TRACK = false;
 
 static
 NSData *loadImage(NSString *path)
 {
     if (path == nil)
         return nil;
-
-    NSImage *image = [[NSImage alloc] initWithContentsOfFile:path]; 
+    
+    NSImage *image = [[NSImage alloc] initWithContentsOfFile:path];
     NSImage *scaledImage = nil;
     
     if (image == nil)
         return nil;
     
-    NSImageRep *rep = [[image representations] objectAtIndex:0]; 
-    [image setScalesWhenResized:YES]; 
-    [image setSize:NSMakeSize([rep pixelsWide], [rep pixelsHigh])]; 
+    NSImageRep *rep = [[image representations] objectAtIndex:0];
+    [image setScalesWhenResized:YES];
+    [image setSize:NSMakeSize([rep pixelsWide], [rep pixelsHigh])];
     
     NSSize origSize = NSMakeSize([rep pixelsWide], [rep pixelsHigh]);
     
@@ -48,27 +49,27 @@ NSData *loadImage(NSString *path)
         }
         else {
             scaledSize.height = ITUNES_COVER_SIZE;
-            scaledSize.width = origSize.width * ITUNES_COVER_SIZE/origSize.height;                
+            scaledSize.width = origSize.width * ITUNES_COVER_SIZE/origSize.height;
         }
-
+        
         scaledImage = [[[NSImage alloc] initWithSize:scaledSize] retain];
         
         // Composite image appropriately
         [scaledImage lockFocus];
         [[NSGraphicsContext currentContext] setImageInterpolation:NSImageInterpolationHigh];
-        [image drawInRect:NSMakeRect(0, 0, scaledSize.width, scaledSize.height) 
-                    fromRect:NSMakeRect(0, 0, origSize.width, origSize.height)
-                   operation:NSCompositeSourceOver 
-                    fraction:1.0];
+        [image drawInRect:NSMakeRect(0, 0, scaledSize.width, scaledSize.height)
+                 fromRect:NSMakeRect(0, 0, origSize.width, origSize.height)
+                operation:NSCompositeSourceOver
+                 fraction:1.0];
         [scaledImage unlockFocus];
     }
-
+    
     // Cache the reduced image
     NSData *imageData = [scaledImage TIFFRepresentation];
     NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepWithData:imageData];
     NSDictionary *imageProps = [NSDictionary dictionaryWithObject:[NSNumber numberWithFloat:1.0] forKey:NSImageCompressionFactor];
     imageData = [imageRep representationUsingType:NSJPEGFileType properties:imageProps];
-
+    
     [image release];
     return imageData;
 }
@@ -79,9 +80,8 @@ NSData *generateSample(NSString *text, NSString *url)
     int textLength = [text lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
     int urlLength = [url lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
     int atomLength = urlLength + 14;
-    int fullLength = textLength + urlLength + 14;
     int ptr;
-
+    
     unsigned char *atom = (unsigned char*)malloc(textLength + urlLength + 16);
     if (atom == NULL)
         return nil;
@@ -96,11 +96,11 @@ NSData *generateSample(NSString *text, NSString *url)
     atom[ptr++] = atomLength & 0xff;
     memcpy(atom+ptr, "href", 4);
     ptr += 4;
-
+    
     // start position
     atom[ptr++] = 0;
     atom[ptr++] = 0;
-
+    
     // stop position
     atom[ptr++] = (textLength >> 8) & 0xff;
     atom[ptr++] = textLength & 0xff;
@@ -110,16 +110,16 @@ NSData *generateSample(NSString *text, NSString *url)
     ptr += urlLength;
     atom[ptr++] = 0; // no hint
     NSData *result = [NSData dataWithBytes:atom length:ptr];
-
+    
     return result;
 }
 
 
 int addChapters(const char *mp4, NSArray *chapters)
-{ 
+{
     if ([chapters count] == 0)
         return 0;
-
+    
     MP4FileHandle mp4File = MP4Modify( mp4 );
     
     if( mp4File == MP4_INVALID_FILE_HANDLE )
@@ -127,7 +127,7 @@ int addChapters(const char *mp4, NSArray *chapters)
     
     MP4TrackId refTrack = MP4_INVALID_TRACK_ID;
     uint32_t trackCount = MP4GetNumberOfTracks( mp4File );
-
+    
     for( uint32_t i = 0; i < trackCount; ++i ) {
         MP4TrackId id = MP4FindTrackId( mp4File, i );
         const char* type = MP4GetTrackType( mp4File, id );
@@ -139,42 +139,72 @@ int addChapters(const char *mp4, NSArray *chapters)
     
     if( !MP4_IS_VALID_TRACK_ID(refTrack) )
         return -1;
-
-    MP4Duration origTrackDuration = MP4GetTrackDuration( mp4File, refTrack ); 
+    
+    MP4Duration origTrackDuration = MP4GetTrackDuration( mp4File, refTrack );
     uint32_t trackTimeScale = MP4GetTrackTimeScale( mp4File, refTrack );
     MP4Duration trackDuration = origTrackDuration / trackTimeScale;
     vector<MP4Chapter_t> mp4chapters;
-
-    MP4TrackId jpegTrack = MP4AddJpegVideoTrack(mp4File, trackTimeScale, MP4_INVALID_DURATION,
-        300, 300);
-
-#ifdef HAVE_SUBTITLES
-    // Add subtitles
-    MP4TrackId subtitlesTrack = MP4AddSubtitleTrack( mp4File, trackTimeScale, 300, 300 );
-
-    const uint8_t textColor[4] = { 0,0,0,255 };
-
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "tkhd.alternate_group", 0);
-
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.dataReferenceIndex", 1);
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.horizontalJustification", 1);
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.verticalJustification", 255);
-
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.bgColorAlpha", 0);
-
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.defTextBoxBottom", 0);
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.defTextBoxRight", 0);
-
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.fontID", 1);
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.fontSize", 0);
-
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.fontColorRed", textColor[0]);
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.fontColorGreen", textColor[1]);
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.fontColorBlue", textColor[2]);
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.fontColorAlpha", textColor[3]);
-
-    MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "tkhd.flags", 0xf);
-#endif
+    
+    // start: check picture nodes to see if video track is necessary
+    int numPictureTags = 0;
+    int numLinks = 0;
+    for (int idx = 0; idx < [chapters count]; idx++) {
+        Chapter *chapter = [chapters objectAtIndex:idx];
+        if (chapter.artPath != nil) {
+            numPictureTags++;
+        }
+        if (chapter.linkText != nil) {
+            numLinks++;
+        }
+    }
+    if (numLinks != 0) {
+        NSLog(@"Creating subtitle track for hyperlinks...");
+        CREATE_SUBTITLES = true;
+    }
+    
+    MP4TrackId jpegAndOrChapterTrack;
+    if (numPictureTags != 0) {
+        NSLog(@"Creating video track for artwork...");
+        jpegAndOrChapterTrack = MP4AddJpegVideoTrack(mp4File, trackTimeScale, MP4_INVALID_DURATION, 300, 300);
+        CREATE_JPEG_TRACK = true;
+    } else {
+        jpegAndOrChapterTrack = MP4AddChapterTextTrack(mp4File, 1);
+    }
+    // end
+    
+    
+    
+    
+    MP4TrackId subtitlesTrack;
+    if (CREATE_SUBTITLES) {
+        
+        // Add subtitles
+        subtitlesTrack = MP4AddSubtitleTrack( mp4File, trackTimeScale, 300, 300 );
+        
+        const uint8_t textColor[4] = { 0,0,0,255 };
+        
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "tkhd.alternate_group", 0);
+        
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.dataReferenceIndex", 1);
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.horizontalJustification", 1);
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.verticalJustification", 255);
+        
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.bgColorAlpha", 0);
+        
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.defTextBoxBottom", 0);
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.defTextBoxRight", 0);
+        
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.fontID", 1);
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.fontSize", 0);
+        
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.fontColorRed", textColor[0]);
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.fontColorGreen", textColor[1]);
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.fontColorBlue", textColor[2]);
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "mdia.minf.stbl.stsd.tx3g.fontColorAlpha", textColor[3]);
+        
+        MP4SetTrackIntegerProperty(mp4File, subtitlesTrack, "tkhd.flags", 0xf);
+        
+    }
     
     Chapter *firstChapter = [chapters objectAtIndex:0];
     if (firstChapter.startTime != 0) {
@@ -182,19 +212,21 @@ int addChapters(const char *mp4, NSArray *chapters)
         chap.title[0] = '\0';
         chap.duration = firstChapter.startTime;
         mp4chapters.push_back( chap );
-
+        
         NSData *img = [NSData dataWithBytes:__1x1_png length:__1x1_png_len];
-        MP4WriteSample(mp4File, jpegTrack, 
-		    (const uint8_t *)[img bytes], [img length], chap.duration*trackTimeScale/1000);
-
-#ifdef HAVE_SUBTITLES
-		NSData* subtitlesSample = generateSample(@"", @" ");
-
-        MP4WriteSample(mp4File, subtitlesTrack, 
-		    (const uint8_t *)[subtitlesSample bytes], [subtitlesSample length], chap.duration*trackTimeScale/1000);
-#endif
+        MP4WriteSample(mp4File, jpegAndOrChapterTrack,
+                       (const uint8_t *)[img bytes], [img length], chap.duration*trackTimeScale/1000);
+        
+        
+        if (CREATE_SUBTITLES) {
+            NSData* subtitlesSample = generateSample(@"", @" ");
+            
+            MP4WriteSample(mp4File, subtitlesTrack,
+                           (const uint8_t *)[subtitlesSample bytes], [subtitlesSample length], chap.duration*trackTimeScale/1000);
+            
+        }
     }
-
+    
     for (int idx = 0; idx < [chapters count]; idx++) {
         Chapter *chapter = [chapters objectAtIndex:idx];
         MP4Chapter_t chap;
@@ -208,33 +240,32 @@ int addChapters(const char *mp4, NSArray *chapters)
             Chapter *nextChapter = [chapters objectAtIndex:(idx+1)];
             chap.duration = nextChapter.startTime - chapter.startTime;
         }
-        strncpy(chap.title, 
+        strncpy(chap.title,
                 [chapter.title UTF8String], sizeof(chap.title)-1);
         
         mp4chapters.push_back( chap );
-
+        
         NSData *img = nil;
         if (chapter.artPath)
             img = loadImage(chapter.artPath);
         if (img == nil)
             img = [NSData dataWithBytes:__1x1_png length:__1x1_png_len];
-
-        // NSString *name = [NSString stringWithFormat:@"%d.jpg", idx];
-        // [img writeToFile:name atomically:nil];
-
-        MP4WriteSample(mp4File, jpegTrack, 
-		    (const uint8_t *)[img bytes], [img length], chap.duration*trackTimeScale/1000);
-
-#ifdef HAVE_SUBTITLES
-		NSData* subtitlesSample;
-        if (chapter.link != nil)
-		    subtitlesSample = generateSample(chapter.linkText, chapter.link);
-        else
-		    subtitlesSample = generateSample(@"", @" ");
-
-        MP4WriteSample(mp4File, subtitlesTrack, 
-		    (const uint8_t *)[subtitlesSample bytes], [subtitlesSample length], chap.duration*trackTimeScale/1000);
-#endif
+        
+        MP4WriteSample(mp4File, jpegAndOrChapterTrack,
+                       (const uint8_t *)[img bytes], [img length], chap.duration*trackTimeScale/1000);
+        
+        
+        if (CREATE_SUBTITLES) {
+            NSData* subtitlesSample;
+            if (chapter.link != nil)
+                subtitlesSample = generateSample(chapter.linkText, chapter.link);
+            else
+                subtitlesSample = generateSample(@"", @" ");
+            
+            MP4WriteSample(mp4File, subtitlesTrack,
+                           (const uint8_t *)[subtitlesSample bytes], [subtitlesSample length], chap.duration*trackTimeScale/1000);
+            
+        }
     }
     
 #define TRACK_DISABLED 0x0
@@ -242,17 +273,20 @@ int addChapters(const char *mp4, NSArray *chapters)
 #define TRACK_IN_MOVIE 0x2
 #define TRACK_IN_PREVIEW 0x4
 #define TRACK_IN_POSTER 0x8
-
-    MP4SetTrackIntegerProperty(mp4File, jpegTrack, "tkhd.flags", 
-        (TRACK_ENABLED | TRACK_IN_MOVIE | TRACK_IN_PREVIEW | TRACK_IN_POSTER));
-    MP4SetChapters(mp4File, &mp4chapters[0], (int)mp4chapters.size(), MP4ChapterTypeQt);
-
-    MP4AddTrackReference(mp4File, "tref.chap", jpegTrack, refTrack);
-
-    MP4SetTrackLanguage(mp4File, refTrack, "eng");
-    MP4SetTrackLanguage(mp4File, jpegTrack, "eng");
-    MP4SetTrackLanguage(mp4File, subtitlesTrack, "eng");
-    MP4Close(mp4File);
     
+    MP4SetTrackIntegerProperty(mp4File, jpegAndOrChapterTrack, "tkhd.flags",
+                               (TRACK_ENABLED | TRACK_IN_MOVIE | TRACK_IN_PREVIEW | TRACK_IN_POSTER));
+    MP4SetChapters(mp4File, &mp4chapters[0], (int)mp4chapters.size(), MP4ChapterTypeQt);
+    
+    MP4AddTrackReference(mp4File, "tref.chap", jpegAndOrChapterTrack, refTrack);
+    
+    MP4SetTrackLanguage(mp4File, refTrack, "eng");
+    if (CREATE_JPEG_TRACK)
+        MP4SetTrackLanguage(mp4File, jpegAndOrChapterTrack, "eng");
+    if (CREATE_SUBTITLES)
+        MP4SetTrackLanguage(mp4File, subtitlesTrack, "eng");
+    
+    MP4Close(mp4File);
+    NSLog(@"Completed.");
     return 0;
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Krishna Bhamidipati
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
New improvements, making ChapterX behavior more like the original ChapterTool:
- JPEG track only created if at least one <picture> tag is present in input XML
- subtitle track (for hyperlinks) only created if at least one <link> tag is present in XML
- other minor refactoring/code cleanup
